### PR TITLE
ci: publish container image to ghcr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   push:
     branches: [main, master]
+    tags: ["v*"]
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -32,3 +36,37 @@ jobs:
             sleep 1
           done
           scripts/curl-smoke.sh http://localhost:8080
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [test, docker]
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -24,11 +24,18 @@ The full wire contract is in [docs/API.md](docs/API.md).
 ```sh
 docker run -d --name crosspoint-sync \
   -p 8080:8080 \
-  -v "$PWD/data:/data" \
-  ghcr.io/OWNER/crosspoint-sync:latest
+  -v crosspoint-data:/data \
+  ghcr.io/crosspoint-reader/crosspoint-sync:main
 ```
 
-Or from a checkout: `docker compose up -d` (see `docker-compose.yml`).
+Or from a checkout: `docker compose up -d` uses the published image from
+`docker-compose.yml`.
+
+For local image builds from the checkout, use:
+
+```sh
+docker compose -f docker-compose.dev.yml up -d --build
+```
 
 ### Railway (hosted-style deploy)
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   crosspoint-sync:
-    image: ghcr.io/crosspoint-reader/crosspoint-sync:main
+    build: .
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
This actually builds and publishes the container to GHCR.

Also updated the README to point to that image, and separated a development-docker-compose-setup for local development.

I also wanted to add a renovate-setup for the action and Dockerfile, but not sure if that is wanted or not - it would require installing renovate as an app for the repo first I think.

Probably would also be useful for the node-dependencies.